### PR TITLE
Add support for destructive actions on iOS

### DIFF
--- a/lib/platform_action_sheet.dart
+++ b/lib/platform_action_sheet.dart
@@ -54,6 +54,7 @@ CupertinoActionSheetAction _cupertinoActionSheetActionFromAction(
       child: Text(action.text),
       onPressed: action.onPressed,
       isDefaultAction: action.defaultAction,
+      isDestructiveAction: action.destructiveAction,
     );
 
 ListTile _listTileFromAction(ActionSheetAction action) => action.hasArrow
@@ -121,6 +122,9 @@ class ActionSheetAction {
   /// Is this a default action - especially for iOS
   final bool defaultAction;
 
+  /// Is this a destructive action - especially for iOS
+  final bool destructiveAction;
+
   /// This is a cancel option - especially for iOS
   final bool isCancel;
 
@@ -132,6 +136,7 @@ class ActionSheetAction {
     @required this.text,
     @required this.onPressed,
     this.defaultAction = false,
+    this.destructiveAction = false,
     this.isCancel = false,
     this.hasArrow = false,
   });


### PR DESCRIPTION
This PR adds support for destructive actions on iOS, setting a red color for the action title
![Simulator Screen Shot - iPhone 12 mini - 2021-05-04 at 21 43 56](https://user-images.githubusercontent.com/28107/117089006-3420f300-ad22-11eb-92b6-5bd5fe137a2c.png)

